### PR TITLE
feat: support optional persona/framework.md for post-level voice overrides

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -78,13 +78,17 @@ Read these reference files in order:
 
 1. `persona/voice.md` — The author's voice. Read this first, every time. It contains the
    tone, rhetorical devices, and voice-specific examples.
-2. `references/tone-guide.md` — The generic writing framework. Narrative density rules,
+2. `persona/framework.md` — (If it exists) Post-level architecture: opening modes, argument
+   shape by post type, density philosophy, first-person rules, closing modes, and off-voice
+   moves. **When this file exists, it overrides the "Blog Anatomy" section below and the
+   narrative-density doctrine in `references/tone-guide.md`.** Read it immediately after
+   `voice.md`, before any other reference file.
+3. `references/tone-guide.md` — The generic writing framework. Narrative density rules,
    anti-pattern index, tone calibration, TLDR format.
-3. `references/ai-anti-patterns.md` — 37 named AI writing patterns to never use. Each has
+4. `references/ai-anti-patterns.md` — 37 named AI writing patterns to never use. Each has
    symptoms, examples, structural variants, and alternatives. The anti-pattern check in
    Phase 3 and 4 scans the draft against this file.
-4. `references/process.md` — The workflow from transcript to published draft.
-5. `persona/product.md` — (If it exists and has content) Index of product docs and
+5. `references/process.md` — The workflow from transcript to published draft.
    terminology. Do NOT read the whole thing upfront. Scan it to know what's available, then
    fetch only the specific pages relevant to the post's topic during Phase 0.
 
@@ -146,8 +150,9 @@ shape:
 not prose. Each bullet should make the reader think "wait, really?" not "yeah, obvious."
 Written last, placed first.
 
-**Opening hook** — A personal story, a public embarrassment, a confession. Never a thesis
-statement. Never "In this post, we'll explore..."
+**Opening hook** — **If `persona/framework.md` exists, use its opening modes instead of
+this description.** Generic default: a personal story, a public embarrassment, a
+confession. Never a thesis statement. Never "In this post, we'll explore..."
 
 **The problem, demonstrated** — Show the failure. Screenshots, code, terminal output. Let the
 reader feel the pain before offering the fix.

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,6 +89,7 @@ Read these reference files in order:
    symptoms, examples, structural variants, and alternatives. The anti-pattern check in
    Phase 3 and 4 scans the draft against this file.
 5. `references/process.md` — The workflow from transcript to published draft.
+6. `persona/product.md` — (If it exists and has content) Index of product docs and
    terminology. Do NOT read the whole thing upfront. Scan it to know what's available, then
    fetch only the specific pages relevant to the post's topic during Phase 0.
 
@@ -139,6 +140,10 @@ The anti-pattern check is a **defined procedure**, not a vibe check.
 
 ## Quick Reference: Blog Anatomy
 
+> **Fallback only.** If `persona/framework.md` exists, that file governs post-level
+> architecture (opening modes, argument shape, density philosophy, closing modes) and
+> overrides this entire section. Read it instead.
+
 Posts are stories about real problems that happen to involve a technology (and optionally a
 product). The reader should learn something even if they never touch the author's stack.
 
@@ -150,9 +155,8 @@ shape:
 not prose. Each bullet should make the reader think "wait, really?" not "yeah, obvious."
 Written last, placed first.
 
-**Opening hook** — **If `persona/framework.md` exists, use its opening modes instead of
-this description.** Generic default: a personal story, a public embarrassment, a
-confession. Never a thesis statement. Never "In this post, we'll explore..."
+**Opening hook** — A personal story, a public embarrassment, a confession. Never a thesis
+statement. Never "In this post, we'll explore..."
 
 **The problem, demonstrated** — Show the failure. Screenshots, code, terminal output. Let the
 reader feel the pain before offering the fix.


### PR DESCRIPTION
**Author-Model:** claude-sonnet-4-6

The skill reads `persona/voice.md` for sentence-level voice (rhetorical devices, tone, vocabulary) but had no way to load post-level architecture preferences — opening modes, argument shape by post type, density philosophy, closing modes, off-voice moves.

Without this, the skill ignores any per-author structural preferences and falls back to the generic Blog Anatomy, including a hardcoded "Opening hook = personal story/confession" that conflicts with many technical writers's actual practice (news-lead, concept definition, direct position claim are all common in the developer blog space).

**The fix:** if `persona/framework.md` exists in the persona directory, read it immediately after `voice.md` and let it override the Blog Anatomy section and tone-guide narrative density rules. Nothing changes for personas that don't have this file — the skill behaves exactly as before.