### PR TITLE
ci(publish): authenticate with TESSL_TOKEN

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: tesslio/setup-tessl@v2
         with:
-          token: ${{ secrets.TESSL_API_TOKEN }}
+          token: ${{ secrets.TESSL_TOKEN }}
       - run: tessl skill review --threshold 85
       - uses: tesslio/patch-version-publish@v1
         with:
-          token: ${{ secrets.TESSL_API_TOKEN }}
+          token: ${{ secrets.TESSL_TOKEN }}


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

The `Review & Publish Tile` workflow authenticates with `secrets.TESSL_API_TOKEN` (created Feb 2026), which now returns **401 Unauthorized** — the `tessl skill review --threshold 85` gate fails and `patch-version-publish` is skipped. First surfaced on the push that merged #7 (the first publish run since the token went stale; last success was April 13).

Switch both `setup-tessl` and `patch-version-publish` to the current **`TESSL_TOKEN`** secret.

## Test plan

- [ ] On merge, the push-to-`main` publish run authenticates cleanly (no 401) and `tessl skill review` runs
- [ ] `patch-version-publish` proceeds (no longer skipped)