### PR TITLE
test(evals): de-leak scenario-7 and reweight criteria to 100

### DIFF
--- a/evals/scenario-7/criteria.json
+++ b/evals/scenario-7/criteria.json
@@ -1,41 +1,41 @@
 {
-  "context": "Tests whether the agent detects and fixes sentence/paragraph craft problems and replaces assessments with facts. The draft has no classic AI vocabulary contamination or structural gimmicks, but suffers from overloaded sentences, cold lists, weak subjects, nested subordination, introductory filler words, amplifier intensifiers, unproven assessment adjectives, euphemistic smoothing, features without benefits, stacked data points, and empty conclusions. Also tests whether the agent flags the absence of honest limitations.",
+  "context": "Tests whether the agent detects and fixes sentence/paragraph craft problems and replaces assessments with facts. The draft has no classic AI vocabulary contamination or structural gimmicks, but suffers from overloaded sentences, cold lists, weak subjects, nested subordination, introductory filler words, amplifier intensifiers, unproven assessment adjectives, euphemistic smoothing, features without benefits, stacked data points, and empty conclusions. Also tests whether the agent flags the absence of honest limitations. The task deliberately does NOT enumerate these problems, so a baseline that does a generic copyedit will miss the tile's specific craft-sweep fixes.",
   "type": "weighted_checklist",
   "checklist": [
     {
       "name": "Overloaded sentence split",
       "description": "The mega-sentence about evaluating 'multiple tools, frameworks, and approaches, including Prometheus, Grafana, Datadog, New Relic, and Thanos, by our infrastructure team over the course of several months in order to determine the best path forward...' is split into multiple sentences, each carrying one idea",
-      "max_score": 8
+      "max_score": 6
     },
     {
       "name": "Cold list generalized",
       "description": "The list of monitoring tools (Prometheus, Datadog, New Relic, Thanos, VictoriaMetrics) is introduced with a category label (e.g., 'five monitoring tools' or 'several observability platforms') before listing them, rather than dropped cold",
-      "max_score": 8
+      "max_score": 6
     },
     {
       "name": "Weak subjects strengthened",
       "description": "'The implementation of a new monitoring solution required...' and 'The presence of outdated monitoring configurations... meant that...' are rewritten with real actors as subjects (e.g., 'We evaluated...' or 'Our Nagios setup had...' or 'Three teams had maintained...')",
-      "max_score": 10
+      "max_score": 8
     },
     {
       "name": "Nested subordination flattened",
       "description": "The deeply nested sentence about the infrastructure team ('which had been working... since January, when we first approved... after the quarterly planning meeting where Sasha presented... that included...') is split into shorter sentences with at most one level of subordination",
-      "max_score": 8
+      "max_score": 6
     },
     {
       "name": "Introductory filler words removed",
       "description": "The filler words 'Of course', 'naturally', 'Obviously', 'Frankly', 'Additionally', 'Furthermore', 'Moreover', 'Also' (as sentence opener), and 'In addition to this' are deleted without changing the sentence meaning",
-      "max_score": 10
+      "max_score": 6
     },
     {
       "name": "Amplifier intensifiers replaced with facts",
       "description": "The 'truly powerful', 'remarkably flexible', 'incredibly active', 'extremely impressed' amplifier + adjective pairs are either replaced with specific evidence (what makes the query language powerful, what makes alerting flexible) or the amplifiers are removed",
-      "max_score": 10
+      "max_score": 9
     },
     {
       "name": "Unproven assessments replaced with evidence",
       "description": "The 'robust, scalable, and comprehensive', 'elegant and innovative approach', and 'seamless observability experience' assessment adjectives are either replaced with facts that prove the claim or removed. The false-work test applies: if stripping the adjectives leaves the sentence empty, it needs research, not better adjectives.",
-      "max_score": 10
+      "max_score": 9
     },
     {
       "name": "Euphemistic smoothing fixed",
@@ -50,12 +50,12 @@
     {
       "name": "Stacked data points trimmed",
       "description": "The four-way data pile ('60%, from $8,400 per month to $3,360 per month, saving us $60,480 annually, which represents a 5x return') is reduced to one or two data points that make the strongest case",
-      "max_score": 8
+      "max_score": 6
     },
     {
       "name": "Empty results replaced with evidence",
       "description": "The vague results ('handles our current load well', 'haven't had any issues', 'team is happy with the tooling') are either replaced with specific metrics or evidence, or flagged in the report as needing facts from the author",
-      "max_score": 10
+      "max_score": 9
     },
     {
       "name": "Honest limitation present or flagged",
@@ -65,7 +65,7 @@
     {
       "name": "No new anti-patterns introduced",
       "description": "The revised draft does NOT introduce AI vocabulary (delve, leverage, tapestry, etc.), parallel binary comparisons, self-answering fragment questions, significance inflation, choppy fragment chains, or other named anti-patterns from the skill's list",
-      "max_score": 6
+      "max_score": 5
     },
     {
       "name": "Technical content preserved",

--- a/evals/scenario-7/task.md
+++ b/evals/scenario-7/task.md
@@ -2,11 +2,9 @@
 
 ## Problem/Feature Description
 
-A staff engineer submitted a blog post about migrating from Nagios to Prometheus. The draft has already been through a basic editing pass -- there are no obvious AI vocabulary problems ("delve", "leverage", "tapestry"), no structural gimmicks (no parallel binaries, no self-answering fragments, no choppy fragment chains), no emoji, and no formatting issues.
+A staff engineer submitted a blog post about migrating from Nagios to Prometheus. It has already had a light copyedit -- no AI-vocabulary tells, no structural gimmicks, no emoji, clean formatting -- but it still reads like a rough draft rather than finished writing.
 
-But the writing has deeper problems. Sentences are overloaded with multiple ideas crammed together. Lists of tools appear without context. Abstract nouns do the work that real actors should. Subordinate clauses nest three levels deep. Adjectives substitute for evidence. Failures are smoothed over with euphemisms. Features are listed as raw specs without explaining what they mean for the reader. And the conclusion is vague assessments where specific results should be.
-
-Review the draft for these craft and substance issues. Produce a revised version that fixes the writing problems while preserving the technical content. Also produce a report documenting each issue and the fix.
+Give it a craft and substance editing pass: sharpen the prose and make its claims concrete, while preserving the technical content. Also produce a report documenting each change you made -- the original text, what was wrong with it, and your replacement.
 
 ## Output Specification
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Follow-up to the eval curation (#10). The 3-run pass flagged scenario-7 (sentence craft & substance) as unstable: ≈+18 across three single runs but −2.7 on a 3-run batch. Two root causes, both fixed here:

- **Leak** — the task's problem description enumerated every fix the criteria grade ("Sentences are overloaded…", "Lists of tools appear without context", "Abstract nouns do the work…", "Failures are smoothed over with euphemisms", "Features are listed as raw specs", "the conclusion is vague assessments"). A baseline read that checklist off the prompt and applied it, scoring ~100 with no tile. Per `jbaruch/coding-policy: plugin-evals` ("No Bleeding"), the task now states only the situation — "give it a craft and substance editing pass" — so the agent must *find* the problems; the tile's craft sweep is what guides it to the specific fixes.
- **Weights** — criteria summed to **118**, letting scores exceed 100 and baseline accumulate past a real ceiling (the source of the −2.7 batch's baseline spike to ~108). Reweighted to exactly **100**, shifting emphasis onto the tile-distinctive facts-over-assessments / honest-limitations criteria and trimming the universal craft ones.

## Test plan
- [ ] `tessl eval run --runs 3` shows scenario-7 baseline dropping (no longer ~100) and lift turning consistently positive
- [ ] criteria weights sum to 100