### PR TITLE
ci(publish): tolerate tessl out-of-credits outage in skill review

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -17,7 +17,35 @@ jobs:
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
-      - run: tessl skill review --threshold 85
+      # Wraps the plugin's own `tessl skill review` call to tolerate a tessl
+      # "out of credits" (403) billing outage: only that signature skips
+      # (publishing unreviewed, self-healing when credits return); every other
+      # non-zero exit still hard-fails. Tracked in jbaruch/coding-policy#188.
+      - name: Skill review (credit-outage tolerant)
+        shell: bash
+        run: |
+          set -eo pipefail
+          set +e
+          review_out="$(tessl skill review --threshold 85 2>&1)"
+          rc=$?
+          set -e
+          printf '%s\n' "$review_out"
+          [ "$rc" -eq 0 ] && exit 0
+          # Require BOTH the credit phrase AND a 403 (fixed-string) so only the
+          # billing outage skips; anything else hard-fails (fail-safe).
+          if printf '%s' "$review_out" | grep -qiF 'run out of credits' \
+             && printf '%s' "$review_out" | grep -qF '403'; then
+            resume="$(date -u -d "$(date -u +%Y-%m-01) +1 month" +%Y-%m-01)" || resume="the 1st of next month"
+            echo "::warning::tessl org out of credits (403) — skipping skill review. Publishing UNREVIEWED; resumes by $resume (monthly reset)."
+            {
+              echo "### ⚠️ Skill review skipped — tessl credits exhausted"
+              echo ""
+              echo "Publishing **without** review (tessl 403). Self-heals when credits return; resumes by **$resume**. Tracking: jbaruch/coding-policy#188."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "::error::tessl skill review failed (exit $rc) — not a credits outage; blocking publish."
+          exit "$rc"
       - uses: tesslio/patch-version-publish@v1
         with:
           token: ${{ secrets.TESSL_TOKEN }}


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

**CI-scoped change** (publish workflow only) — per `coding-policy: ci-safety`, a PR whose stated scope is the CI change is the approval artifact.

## Problem

When the tessl org runs out of credits, `tessl skill review` fails with `403 — run out of credits`, failing the entire publish on a billing state the author cannot fix — blocking every merge.

## Change

Wraps the skill-review step so **only** a credit-outage signature (the `run out of credits` phrase **and** a `403`, fixed-string) skips — publishing unreviewed, flagged in the run summary, self-healing when credits return. **Every other** non-zero exit still hard-fails. For action-based workflows this vendors the pinned `skill-review` script inline (a `uses:` step cannot be classified by error content from the consumer); reverts to `uses:` once **jbaruch/coding-policy#188** lands a native credit-outage input. Same fix already shipped across the nanoclaw plugins and `nanoclaw-travel` #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)