### PR TITLE
Incorporate gap patterns from petergyang/no-ai-slop

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: blog-writer
 description: >
   Write developer blog posts from video transcripts, meeting notes, or rough ideas.
   Extracts narrative from source material, structures content with hooks and technical sections,
-  formats code examples with placeholders, and checks drafts against 37 AI anti-patterns.
+  formats code examples with placeholders, and checks drafts against 38 AI anti-patterns.
   Use this skill whenever the user wants to write a blog post, draft a blog, turn a transcript
   into a blog, work on blog content, or mentions "blog" in the context of content creation.
   Also trigger when the user provides a video transcript and wants written content derived from it,
@@ -87,7 +87,7 @@ Read these reference files in order:
    Read it immediately after `persona/voice.md`, before any other reference file.
 3. `references/tone-guide.md` — The generic writing framework. Narrative density rules,
    anti-pattern index, tone calibration, TLDR format.
-4. `references/ai-anti-patterns.md` — 37 named AI writing patterns to never use. Each has
+4. `references/ai-anti-patterns.md` — 38 named AI writing patterns to never use. Each has
    symptoms, examples, structural variants, and alternatives. The anti-pattern check in
    Phase 3 and 4 scans the draft against this file.
 5. `references/process.md` — The workflow from transcript to published draft.
@@ -129,14 +129,15 @@ The anti-pattern check is a **defined procedure**, not a vibe check.
    alternatives — not your general knowledge of AI writing patterns.
 
 2. **Follow the three-pass procedure exactly as written in `references/process.md`.** Pass 1
-   is the surface scan against all 37 patterns. Pass 2 is the skeleton scan on adjacent
+   is the surface scan against all 38 patterns. Pass 2 is the skeleton scan on adjacent
    sentence pairs. Pass 3 is the soul check — a holistic read for sterile, voiceless writing
    that passes pattern checks but still reads as AI. Then the rewrite audit. Then the voice
-   check. In that order. Do not skip passes, do not merge them, do not substitute your own
-   method.
+   check. Then the proportionality check — was the amount of rewriting proportional to the
+   slop found, and would the author still recognize the draft as their own voice. In that
+   order. Do not skip passes, do not merge them, do not substitute your own method.
 
 3. **Do not invent patterns that aren't in the file.** If something feels "AI-ish" but
-   doesn't match any of the 37 defined patterns or their structural variants, leave it
+   doesn't match any of the 38 defined patterns or their structural variants, leave it
    alone. False positives from improvised rules damage the author's voice more than the
    pattern they're trying to fix.
 

--- a/references/ai-anti-patterns.md
+++ b/references/ai-anti-patterns.md
@@ -220,6 +220,12 @@ The question can be any length. The tell is the structure, not the word count.
   — Full-clause question, still only exists to deliver the punchline.
 - Any sentence you could restructure as "[statement]. [period]" without losing information
   is this pattern wearing a question mark as a costume.
+- **The colon reveal** — the same setup/punchline couplet with a colon instead of a
+  question mark. "The best part: it learns." "The result: a cleaner architecture." "The
+  detail that makes it work: a separate agent grades it." A noun phrase, a colon, then a
+  dramatic reveal. No question mark anywhere, but structurally identical: fake tension,
+  then the payoff. Colons are for lists, labels, and quotes — not for drama. Rewrite as a
+  plain sentence: "A separate agent does the grading, and that's what makes it work."
 
 **Why it's a tell:** It creates fake dramatic tension where none exists. It's a
 formatting trick pretending to be rhetoric — a setup/punchline couplet disguised
@@ -342,6 +348,11 @@ The watchlist (delete unless doing real grammatical work):
   start as filler), "in addition to this"
 - **Downtoners:** "somewhat", "rather", "quite", "fairly", "pretty much" — these soften
   claims that should either be stated directly or supported with evidence
+- **Empty framing phrases:** "at the end of the day", "when it comes to", "at its core",
+  "the reality is", "the truth is", "in terms of", "with regard to" — multi-word wrappers
+  that delay the point. "When it comes to testing, coverage matters" is "Test coverage
+  matters" with a warm-up lap. "The reality is" and "the truth is" imply everything else
+  you wrote was neither.
 
 **The delete test:** remove the filler word and re-read the sentence. If the meaning is
 identical, the word was scaffolding. If the sentence now reads as too abrupt or loses a
@@ -379,7 +390,8 @@ a model but scream machine to a reader.
 Verbs: "delve", "underscore", "highlight" (as verb), "foster", "leverage", "harness",
 "showcase", "streamline", "navigate" (abstract), "cultivate", "illuminate", "orchestrate",
 "spearhead", "bolster", "enhance" (when inflating mundane improvements), "garner",
-"align with", "resonate with", "exemplify", "encompass"
+"align with", "resonate with", "exemplify", "encompass", "embark" (on a journey/effort),
+"elevate" (figurative: "elevate your workflow")
 
 Pretentious-for-no-reason verbs (use the plain alternative): "utilize" (use), "leverage"
 (use), "facilitate" (help, enable), "demonstrate" (show), "implement" (build, add, write —
@@ -387,14 +399,14 @@ when the verb is vague filler, not a technical term), "optimize" (improve, speed
 when vague), "indicate" (show, mean), "enable the creation of" (let you create)
 
 Nouns: "tapestry", "landscape" (abstract), "realm", "journey" (abstract), "ecosystem",
-"paradigm", "trajectory", "blueprint", "interplay", "intricacies", "testament", "focal
-point", "commitment" (abstract), "diverse array"
+"paradigm", "trajectory", "blueprint", "interplay", "intricacies", "testament", "beacon",
+"focal point", "commitment" (abstract), "diverse array", "game changer"
 
 Pretentious-for-no-reason nouns: "functionality" (feature), "methodology" (method, approach),
 "utilization" (use), "implementation" (when used as a noun to avoid a verb: "the
 implementation of X" → "we built X")
 
-Adjectives: "pivotal", "crucial", "vital", "nuanced", "multifaceted", "robust", "seamless",
+Adjectives: "pivotal", "crucial", "vital", "paramount", "nuanced", "multifaceted", "robust", "seamless",
 "comprehensive", "cutting-edge", "groundbreaking", "transformative", "enduring", "vibrant",
 "meticulous/meticulously", "renowned", "nestled", "profound", "rich" (figurative: "rich
 history", "rich cultural heritage"), "key" (as adjective: "key role", "key turning point"),
@@ -403,7 +415,8 @@ history", "rich cultural heritage"), "key" (as adjective: "key role", "key turni
 Inflation phrases: "plays a significant role in shaping", "serves as a testament to",
 "it is important to note", "a vibrant tapestry of", "in the heart of", "setting the stage
 for", "reflects broader", "deeply rooted", "marks/represents a significant shift",
-"evolving landscape", "Additionally," (as sentence opener — research-backed strong tell)
+"evolving landscape", "this is huge", "Additionally," (as sentence opener — research-backed
+strong tell)
 
 **Why it's a tell:** Research tracking word frequency before and after ChatGPT shows
 "delve" spiked 10-50x, "tapestry" and "landscape" (abstract) 5-20x, and "plays a
@@ -1109,6 +1122,14 @@ The telegraph can be subtle.
 - "The part that really matters is..." — same move with different words.
 - "This next part is crucial:" — labeling the importance of what follows rather than letting
   the content earn its own weight.
+- **Faux-insight setups:** "What nobody tells you...", "The part everyone misses...",
+  "What most people get wrong...", "Here's what they don't want you to know...". Same
+  telegraph, plus an extra move: it flatters the writer as the lone expert and the reader
+  as the initiated insider. Neither has earned it. "The part everyone misses: distribution
+  is the real moat" becomes "Distribution is the moat" — if the claim is genuinely
+  non-obvious, the reader will notice without being told everyone else is blind.
+- **The Matrix setup:** "What if I told you..." — a rhetorical question that exists only
+  to make its own answer sound revelatory. Delete the setup, state the claim.
 - Any sentence that could be deleted while leaving the following sentence perfectly intact is
   this pattern.
 
@@ -1496,3 +1517,49 @@ If it was slow, say how slow. The reader respects honesty more than polish.
 Euphemistic smoothing is the opposite of the blog's core principle: show the failure, earn
 trust, then show the fix. If you smooth the failure, there's nothing to fix and nothing to
 trust.
+
+---
+
+## 38. Fake-Profound Kickers
+
+**The tell:** The post or section ends on a "deep" line — a cute metaphor, an aphorism, or
+a mic-drop sentence that reframes the concrete story as a universal truth. The ending
+performs profundity instead of earning it.
+
+**Symptoms:**
+- The final sentence is a metaphor that appeared nowhere else in the post
+- The ending zooms out from the specific story to a life lesson
+- The last line would work as an inspirational poster or a fortune cookie
+- Reads like the writer is stepping toward the microphone drop in slow motion
+
+**Examples:**
+- ❌ "In the end, the real bug was never in the code. It was in how we thought about code."
+- ❌ "Maybe the best deploy pipeline is the one you never have to think about."
+- ❌ "The agent didn't just write our tests. It taught us what testing means."
+- ❌ "Because at the end of the day, software is people."
+
+**Structural variants:**
+- The aphorism can be section-level, not just post-level: a paragraph that ends its section
+  with a zoomed-out "and isn't that what engineering is really about?" beat.
+- The callback kicker: reusing an earlier image ("the 2 AM rollback") but inflating it into
+  a metaphor for everything. Callbacks are good; callbacks promoted to universal truths are
+  this pattern.
+- The rhetorical-question kicker: ending on "And isn't that the point?" — a question that
+  performs depth instead of asking anything.
+
+**Why it's a tell:** LLMs end on fake-profound kickers because their training data rewards
+closure — essays that "land." But the profundity is generated, not earned; the metaphor is
+assembled from the post's keywords, not from insight. The reader can feel the difference
+between an ending that follows from the story and one that's been draped over it.
+
+**The repair rule — delete, don't rewrite:** When you catch a fake-profound kicker, the fix
+is NOT a better metaphor. An LLM asked to fix a bad kicker will produce a shinier bad
+kicker — same costume, better tailoring. Delete the line entirely and end on the strongest
+concrete sentence already in the draft. If the ending then feels abrupt, the problem is a
+missing fact or a missing CTA, not a missing aphorism.
+- ✅ "We added input validation. The error rate dropped from twelve per hour to zero." (End
+  there. No lesson about what error rates teach us about ourselves.)
+
+**Carve-out:** The author bio ends with a deliberate kicker (see `persona/bio.md`) — that's
+a schema element, a joke connected to the post's content, not a profundity claim. This
+pattern is about body prose endings. The bio kicker stays.

--- a/references/process.md
+++ b/references/process.md
@@ -344,7 +344,7 @@ up what the reader is about to see, show it, then interpret what matters about i
 Run the anti-pattern check (three passes). Open `references/ai-anti-patterns.md` and scan
 the draft:
 
-**Pass 1 — Surface scan:** Read the draft against each of the 37 patterns, looking for
+**Pass 1 — Surface scan:** Read the draft against each of the 38 patterns, looking for
 the forms described in the examples and structural variants. For the following patterns,
 do a dedicated mechanical sweep instead of relying on contextual reading alone:
 
@@ -435,7 +435,7 @@ not checking against specific patterns but reacting to the overall feel. Look fo
 - Uniform energy — every paragraph has the same emotional temperature
 - Press-release tone — sounds like it was written to impress rather than to communicate
 
-A draft can pass all 37 patterns and still read as obviously AI because it has no soul. If
+A draft can pass all 38 patterns and still read as obviously AI because it has no soul. If
 Pass 3 flags the draft as sterile, the fix is not another anti-pattern rewrite — it's going
 back to `persona/voice.md` and injecting the author's actual rhetorical devices, opinions,
 and attitude into the flat sections.
@@ -443,7 +443,7 @@ and attitude into the flat sections.
 Rewrite any hits. This is not optional.
 
 **Rewrite audit:** After rewriting any anti-pattern hit, re-read the replacement sentence
-in isolation and check it against ALL 37 patterns. Rewrites frequently introduce the same
+in isolation and check it against ALL 38 patterns. Rewrites frequently introduce the same
 pattern in a different surface form. This is especially true for:
 - #2 (Parallel Binary) — the most likely pattern to survive a rewrite, because describing
   a comparison naturally produces mirrored clauses. If you rewrote a parallel binary and the
@@ -452,13 +452,25 @@ pattern in a different surface form. This is especially true for:
 - #6 (Self-Answering Fragment) — rewrites often turn "The result? Great." into a longer
   question with a longer answer, but the structure is identical.
 
-Do not consider an anti-pattern fixed until the replacement passes a full 37-pattern scan
+Do not consider an anti-pattern fixed until the replacement passes a full 38-pattern scan
 on its own.
 
 **Voice check:** After confirming the rewrite is anti-pattern clean, re-read it against
 `persona/voice.md`. Does it still sound like the author? If the rewrite is correct but
 flat, redo it using the author's rhetorical devices. A mechanically clean sentence that
 sounds like a different person is not a fix.
+
+**Proportionality check:** After all rewrites are done, compare the edited draft against
+the pre-scan version and ask two questions at the draft level:
+- Is the amount of rewriting proportional to the actual slop found? If the scan flagged
+  five sentences and forty changed, the editing pass over-reached. Zero tolerance applies
+  to the named patterns — not to everything in their vicinity.
+- Would the author recognize this draft as their own voice? The scan's failure mode is
+  laundering the voice out along with the patterns: every paragraph equally tidy, every
+  edge sanded off, distinctive lines rewritten "for consistency." A voice device that
+  merely resembles a pattern (the carve-outs in `ai-anti-patterns.md` list the known
+  cases) stays. If the answer to this question is no, restore the human sentences the
+  scan didn't actually flag.
 
 Run the product accuracy check (if configured). If `persona/product.md` exists and contains
 content, verify every claim the draft makes about the product — feature names, CLI commands,
@@ -518,7 +530,7 @@ conversation — edit the file surgically.
 - Re-run the anti-pattern check (`references/ai-anti-patterns.md`) after changes — all
   three passes (surface scan + skeleton scan + soul check) for new or rewritten sections.
   Apply the rewrite
-  audit rule: every rewrite must pass a full 37-pattern scan on its own before it's
+  audit rule: every rewrite must pass a full 38-pattern scan on its own before it's
   considered fixed. Then run the voice check: re-read against `persona/voice.md` and
   redo any rewrite that's clean but flat. New writing can introduce new patterns
 - Re-run the product accuracy check if any product feature descriptions, commands, or

--- a/references/tone-guide.md
+++ b/references/tone-guide.md
@@ -61,7 +61,7 @@ conference afterparty, not a whitepaper.
 
 ## Anti-Patterns: What to Never Do
 
-**Read `references/ai-anti-patterns.md` for the full list.** It contains 37 named patterns
+**Read `references/ai-anti-patterns.md` for the full list.** It contains 38 named patterns
 with symptoms, examples, and alternatives. Scan the draft against every one of them during
 Phase 3 and Phase 4. Zero tolerance.
 
@@ -71,7 +71,7 @@ Quick index for scanning:
 3. Asyndetic tricolon with a kicker — "X. Y. Z. And then..."
 4. Choppy fragment chains — noun-phrase fragments as drama
 5. Symmetrical LLM patterns — fortune-cookie balance
-6. Self-answering fragment questions — "The result? Great."
+6. Self-answering fragment questions — "The result? Great."; colon reveals — "The best part: it learns."
 7. Parenthetical em-dashes — paired dashes as fancy commas
 8. Excessive em-dashes — more than two per section
 9. Preamble announcements — "In this post, we'll explore..."
@@ -103,6 +103,7 @@ Quick index for scanning:
 35. Temporal filler (time parasites) — "In today's rapidly evolving landscape", "now more than ever"
 36. Corporate cliché phrases — "passionate team", "end-to-end solution", "trusted by industry leaders"
 37. Euphemistic smoothing — "encountered challenges" instead of "it broke"; softening failures
+38. Fake-profound kickers — mic-drop metaphor endings; delete, don't rewrite into a better metaphor
 
 ---
 
@@ -407,7 +408,7 @@ Before submitting a draft, check:
 - [ ] Run a final anti-pattern check: surface scan (match examples and structural variants),
   then skeleton scan (compare grammatical structure of adjacent sentences), then soul check
   (holistic read for sterile, voiceless writing). Rewrite any hits, then re-check each
-  rewrite against all 37 patterns before considering it fixed.
+  rewrite against all 38 patterns before considering it fixed.
 
 ---
 


### PR DESCRIPTION
Cross-referenced our 37-pattern catalog against [petergyang/no-ai-slop](https://github.com/petergyang/no-ai-slop) (MIT). Most of their catalog maps onto patterns we already cover in more depth; this PR folds in the four things we were actually missing.

## Changes

- **Colon reveals** — "The best part: it learns." Added as a structural variant of #6 (self-answering fragment questions). Same setup/punchline couplet, colon instead of question mark.
- **Faux-insight setups** — "What nobody tells you...", "The part everyone misses...", plus the Matrix setup ("What if I told you..."). Added as variants of #30 (telegraphing transitions).
- **New pattern #38: fake-profound kickers** — the mic-drop metaphor/aphorism ending. Includes the repair rule worth stealing: delete the kicker, do NOT rewrite it into a better metaphor (an LLM asked to fix a bad kicker produces a shinier bad kicker). Carve-out for the deliberate bio kicker.
- **Proportionality check** in the Phase 3 procedure (process.md + SKILL.md summary): cutting must be proportional to the slop actually found, and the author must still recognize the draft as their own voice. Counterweight to the zero-tolerance scan's over-sanitization failure mode.
- **Watchlist additions**: "at the end of the day", "when it comes to", "at its core", "the reality is/the truth is" (#10); "embark", "elevate", "beacon", "game changer", "paramount", "this is huge" (#12).
- Pattern count bumped 37 → 38 everywhere it appears (SKILL.md, tone-guide.md, process.md).

Not taken from no-ai-slop: everything else — their binary contrasts, em-dash rules, weasel attribution, synonym cycling etc. are subsets of our existing patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01How7BpbxTcMm29Rd4JnJTJ