### PR TITLE
Add published Tessl posts to persona examples

### DIFF
--- a/persona/examples.md
+++ b/persona/examples.md
@@ -1,0 +1,23 @@
+# Example Posts: Baruch Sadogursky / Tessl
+
+The following published posts define the canonical tone. When adding new examples, add them
+to this list with a one-line note about what they demonstrate.
+
+## "Our AI is the bright kid with no manners, part 1"
+URL: https://tessl.io/blog/our-ai-is-the-bright-kid-with-no-manners-part-1/
+Series: Good OSS Citizen, Episode 1
+Key patterns: Potluck-parking-in-the-flowerbed analogy for the code-quality-vs-social-context
+gap; "The rage is real and justified. But the diagnosis is wrong." as a punchy two-sentence
+reversal; Moses/Mel Brooks aside used as load-bearing structural metaphor (scripture /
+commandments / rituals); research-first credibility (16 documented failure modes) before the
+solution reveal; 15% → 99% as the data punchline that earns the product pitch.
+
+## "Our AI is the bright kid with no manners, part 2"
+URL: https://tessl.io/blog/our-ai-is-the-bright-kid-with-no-manners-part-2/
+Series: Good OSS Citizen, Episode 2
+Key patterns: Confession-as-thesis opening ("I bet against my own eval"); open-book-exam
+analogy for why synthetic evals lie; Kahneman parole-judges aside for LLM variance; "like
+watching someone who knows they should floss but only remembers when they're already in bed"
+for nondeterministic agent behavior; commandments/scripture/rituals algorithm rendered as a
+numbered decision tree; optimizer-vs-eval tension where the style reviewer fights the eval
+results and the eval always wins.


### PR DESCRIPTION
Populates the previously empty `persona/examples.md` with the two published "Our AI is the bright kid with no manners" posts as canonical tone references, each annotated with the voice patterns it demonstrates (confession-as-thesis opening, load-bearing asides, data punchlines, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01How7BpbxTcMm29Rd4JnJTJ