### PR TITLE
Ignore local agent config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 .codex/
 .mcp.json
 persona/
+.agents/
+.vscode/
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
Adds `.agents/`, `.vscode/`, `AGENTS.md`, and `CLAUDE.md` to `.gitignore` — local harness/editor configuration that shouldn't ship with the tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01How7BpbxTcMm29Rd4JnJTJ