### PR TITLE
Ignore .github/skills/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 persona/
 .agents/
 .vscode/
+.github/skills/
 AGENTS.md
 CLAUDE.md


### PR DESCRIPTION
Adds `.github/skills/` to `.gitignore`, completing the local-config cleanup from #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01How7BpbxTcMm29Rd4JnJTJ