### PR TITLE
ci(review): upgrade jbaruch/coding-policy PR review setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# GitHub Actions secret — set in repo Settings → Secrets and variables → Actions,
+# NOT copied into .env:
+#   https://github.com/jbaruch/blog-writer/settings/secrets/actions
+# FLEET_DISPATCH_TOKEN — the token .github/workflows/review-trigger.yml reads to start the
+#   review run in jbaruch/coding-policy. Create it with Actions: Read and write on
+#   jbaruch/coding-policy.
+FLEET_DISPATCH_TOKEN=
+
 # CI reviewer secrets for the jbaruch/coding-policy gh-aw PR review workflows.
 # Set as GitHub Actions repository secrets:
 #   https://github.com/jbaruch/blog-writer/settings/secrets/actions

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,15 +1,15 @@
 name: Trigger fleet policy review
 
-# PR-time trigger for the central jbaruch/coding-policy fleet reviewer. On every
-# same-repo PR event this fires a single-PR review in coding-policy immediately,
-# so the policy verdict is available before merge (the coding-policy cron poll is
-# only a backstop). Fork PRs are skipped — they cannot read the dispatch secret.
+# On each pull request in this repo, starts a review of that PR against the
+# jbaruch/coding-policy coding rules, so the result is available before merge. The
+# jbaruch/coding-policy schedule reviews the same PRs as a backstop. Fork pull
+# requests are skipped (they cannot read the secret). Dependabot pull requests are
+# skipped too (the dependabot actor gets no secrets); the schedule covers them.
 #
 # Requires one repo secret (set it at
 # https://github.com/<owner>/<repo>/settings/secrets/actions for this repo):
-#   FLEET_DISPATCH_TOKEN — a fine-grained PAT scoped to ONLY jbaruch/coding-policy
-#     with `Actions: write` (nothing else). It can trigger the review workflow and
-#     nothing more. The Codex credential itself lives only in coding-policy.
+#   FLEET_DISPATCH_TOKEN — the token this workflow reads to start the review run in
+#     jbaruch/coding-policy. Create it with Actions: Read and write on jbaruch/coding-policy.
 
 on:
   pull_request:
@@ -24,7 +24,11 @@ concurrency:
 jobs:
   trigger:
     # Fork PRs cannot read secrets — skip them (adopt via the adopt-fork-pr skill).
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot's actor also gets no secrets, so its request can't authenticate —
+    # skip it too (the coding-policy cron poll reviews dependabot PRs instead).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch the single-PR review to coding-policy
@@ -36,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "error: FLEET_DISPATCH_TOKEN secret is empty — set a fine-grained PAT (Actions: write on jbaruch/coding-policy only); see this workflow's header" >&2
+            echo "error: FLEET_DISPATCH_TOKEN secret is empty — set a fine-grained token scoped to Actions: Read and write on jbaruch/coding-policy only; see this workflow's header" >&2
             exit 1
           fi
           gh workflow run fleet-review.yml \


### PR DESCRIPTION
Refreshes this repo's `jbaruch/coding-policy` reviewer artifacts to the currently installed plugin version.

**Version diff:** outgoing — not recorded in-repo; the reviewer files were installed 2026-07-20 in b134970 (`jbaruch/coding-policy#202`). Incoming — **0.3.151**, the version pinned in `tessl.json`.

## What this PR commits

- `.github/workflows/review-trigger.yml` — on each pull request, starts a review of that PR against the `jbaruch/coding-policy` rules so the result is available before merge. **Overwritten** by this upgrade.
- `.github/fleet-review-enabled` — an opt-in marker; while it is present, the same review also runs on a schedule as a backstop. The result posts as a `coding-policy-fleet-reviewer[bot]` review. **Unchanged.**
- `.github/copilot-instructions.md` — points Copilot at the code-quality lane (correctness, bugs, security, test gaps). **Unchanged.**
- `.env.example` — records the `FLEET_DISPATCH_TOKEN` name and where to set it, per the `no-secrets` rule. **Appended** — the secret was previously undocumented here even though the trigger workflow already required it.

The rule review and Copilot are separate lanes. The rule review gates the merge on blocking findings (correctness, security, policy-contract); Copilot is always advisory — read it, but it never gates.

### What actually changed in the trigger workflow

Beyond the header rewording, one behavioral change: the job now also skips Dependabot pull requests, not just fork PRs. The Dependabot actor gets no secrets, so its dispatch could not authenticate and the job would fail on every Dependabot PR. This repo has `.github/dependabot.yml`, so that path is live here. The scheduled backstop reviews those PRs instead.

## Required secret

- `FLEET_DISPATCH_TOKEN` — the token `.github/workflows/review-trigger.yml` reads. **Already set on this repo** (since 2026-07-21), so no operator action is needed for this merge. Fork and Dependabot pull requests skip the trigger anyway (they can't read the secret); the scheduled backstop covers them.

## Load indicator

The fleet review's summary begins `Policy loaded: N rule files from jbaruch/coding-policy.` and each finding names the violated rule in bold (e.g. `**ci-safety**`). Seeing the `Policy loaded:` line confirms the poller's `tessl install` loaded the policy. A summary that never reports `Policy loaded: N rule files` is a signal the install step did not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E12jkHg5pDGETwXvckgsEj
