### PR TITLE
Close two anti-pattern detection gaps (#22, #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- **Pattern #1 missed the "X rather than Y" variant** (#22) — the reference covered "Not X, but Y" and "Not just X, but also Y" but not the comparative form, which does identical structural work (negation plus affirmation competing for one slot) while reading as measured prose. It is the hardest of the three to catch by eye, because it does not sound like a mic drop. Added the variant to pattern #1 and a literal "rather than" sweep to the Pass 1 mechanical checks.
+- **Pass 1 had no mechanical check for pattern #7** (#5) — only #8's em-dash density count existed, so paired em-dashes collapsed into "too many em-dashes" and individual occurrences survived all three passes. Added a #7 sweep that flags every ` — X — ` pair regardless of count, and made #8's entry state that it is the density check only, so a passing count no longer reads as clearing #7.
 - **Eval scenario-2 (voice-profile onboarding) was scoring 0/0** — its output spec and all 11 criteria targeted the absolute `~/.claude/blog-writer-persona/` path, which the eval grader (working-directory only) cannot see, so every criterion failed in both baseline and with-context. Redirected outputs to the working directory; the scenario now grades real output (baseline 91 → with-context 100).
 
 ### Removed

--- a/references/ai-anti-patterns.md
+++ b/references/ai-anti-patterns.md
@@ -29,6 +29,12 @@ The negation doesn't have to lead the sentence or use the word "Not."
   position.
 - Any "[positive claim], not [contrasting thing]" at the end of a sentence is this pattern
   in a less obvious position.
+- "X rather than Y" — the same contrast wearing a comparative. "The agent inherits the
+  developer's permissions rather than the automation account's." Reads as measured prose,
+  but it is still negation-then-affirmation with "rather than" doing the work of "not."
+  The hardest of the three to catch by eye: "Not X. Y." announces itself, while this one
+  survives a read precisely because it does not sound like a mic drop. Catch it
+  mechanically: any "rather than" joining two candidates for the same slot.
 - "No tests, no guardrails." / "No spec, no safety net." — Negative parallelism. Two
   "no [noun]" phrases mirrored for dramatic effect. Same mechanism as "Not X. Y." but
   using symmetrical negation instead of negation-then-affirmation.

--- a/references/ai-anti-patterns.md
+++ b/references/ai-anti-patterns.md
@@ -33,8 +33,10 @@ The negation doesn't have to lead the sentence or use the word "Not."
   developer's permissions rather than the automation account's." Reads as measured prose,
   but it is still negation-then-affirmation with "rather than" doing the work of "not."
   The hardest of the three to catch by eye: "Not X. Y." announces itself, while this one
-  survives a read precisely because it does not sound like a mic drop. Catch it
-  mechanically: any "rather than" joining two candidates for the same slot.
+  survives a read precisely because it does not sound like a mic drop. It also fronts:
+  "Rather than the automation account's, the agent inherits the developer's permissions."
+  Catch it mechanically: any "rather than" joining two candidates for the same slot,
+  searched case-insensitively so the sentence-initial form doesn't slip through.
 - "No tests, no guardrails." / "No spec, no safety net." — Negative parallelism. Two
   "no [noun]" phrases mirrored for dramatic effect. Same mechanism as "Not X. Y." but
   using symmetrical negation instead of negation-then-affirmation.

--- a/references/process.md
+++ b/references/process.md
@@ -348,11 +348,22 @@ the draft:
 the forms described in the examples and structural variants. For the following patterns,
 do a dedicated mechanical sweep instead of relying on contextual reading alone:
 
+- **Contrastive negation (#1):** Do a literal search for "rather than". Every hit that
+  joins two candidates for the same slot is pattern #1 wearing a comparative — the
+  negation-then-affirmation is intact, with "rather than" doing the work of "not". The
+  "Not X. Y." form announces itself on a contextual read; this one doesn't, which is
+  exactly why it needs the literal search.
 - **Fragments (#3, #4):** Find every sentence under six words in the draft and check
   whether 3+ appear consecutively. Surrounding sentences can make fragments feel embedded
   when they're actually standalone. Count periods, not vibes.
+- **Parenthetical em-dashes (#7):** Find every paired em-dash (` — X — `) in the draft.
+  Each occurrence is a flag regardless of count. Convert to parentheses, restructure the
+  sentence, or promote the aside to its own clause. This is a usage check, not a density
+  check — a single pair is still a hit, so don't let a passing #8 count clear it.
 - **Em-dashes (#8):** Count em-dashes per section. More than two in a section is a flag.
-  Don't judge whether each em-dash is "justified" — just count them first.
+  Don't judge whether each em-dash is "justified" — just count them first. This is the
+  density check only; individual paired em-dashes are #7's job above, and a section that
+  passes the count can still carry a #7 violation.
 - **AI vocabulary (#12):** Scan the draft for the watchlist words (delve, leverage, tapestry,
   landscape, pivotal, crucial, seamless, etc.). One in a post is fine. Two or more is a
   contamination event. Do a literal word search, not a vibe read — these words hide in

--- a/references/process.md
+++ b/references/process.md
@@ -348,11 +348,13 @@ the draft:
 the forms described in the examples and structural variants. For the following patterns,
 do a dedicated mechanical sweep instead of relying on contextual reading alone:
 
-- **Contrastive negation (#1):** Do a literal search for "rather than". Every hit that
-  joins two candidates for the same slot is pattern #1 wearing a comparative — the
-  negation-then-affirmation is intact, with "rather than" doing the work of "not". The
-  "Not X. Y." form announces itself on a contextual read; this one doesn't, which is
-  exactly why it needs the literal search.
+- **Contrastive negation (#1):** Do a literal, case-insensitive search for "rather than".
+  Every hit that joins two candidates for the same slot is pattern #1 wearing a
+  comparative — the negation-then-affirmation is intact, with "rather than" doing the work
+  of "not". Case matters: "Rather than X, Y" fronts the construction at the start of a
+  sentence, and a case-sensitive search silently misses every one of them. The "Not X. Y."
+  form announces itself on a contextual read; this one doesn't, which is exactly why it
+  needs the literal search.
 - **Fragments (#3, #4):** Find every sentence under six words in the draft and check
   whether 3+ appear consecutively. Surrounding sentences can make fragments feel embedded
   when they're actually standalone. Count periods, not vibes.


### PR DESCRIPTION
Closes #22. Closes #5.

Both issues are the same class of bug, and #22 says so explicitly: a form documented in `references/ai-anti-patterns.md` with no corresponding mechanical sweep in Pass 1, so it survives a contextual read.

## #22 — pattern #1 missed "X rather than Y"

Pattern #1 covered "Not X, but Y" and "Not just X, but also Y" but not the comparative. It does identical structural work — negation plus affirmation competing for the same slot — while reading as measured, professional prose. That is what makes it the hardest of the three to catch: "Not X. Y." announces itself, and this one doesn't.

Added as a structural variant placed directly after the `[positive claim], not [contrasting thing]` bullet, since the issue's motivating example is exactly that bullet with `not` swapped for `rather than`. Added a literal `"rather than"` sweep to Pass 1, the same way #12 and #35 get literal word searches.

## #5 — Pass 1 had no mechanical check for pattern #7

Pass 1 carried only #8's density count, so paired em-dashes were handled as a density problem and individual pairs went undetected through all three passes and the rewrite audit.

Added a #7 sweep that flags every ` — X — ` pair regardless of count, placed immediately before #8 so the split is visible where the two get conflated. Also made #8's entry state that it is the density check only — a section that passes the count can still carry a #7 violation. `ai-anti-patterns.md` already described #7 and #8 as distinct patterns; the gap was Pass 1 alone.

## Not changed

The "38 patterns" count in `SKILL.md`, `plugin.json`, `process.md`, and `tone-guide.md` stays accurate — this adds one structural variant and two sweeps, not new numbered patterns. (Checked because #21 recently fixed a stale count.)

## Why this replaces #25

#25 was stacked on #24 to avoid a conflict in pattern #1's structural-variants list. #24 has since grown well beyond a manifest migration, so this targets `main` directly and carries the identical content. #25 is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E12jkHg5pDGETwXvckgsEj