### PR TITLE
chore(ci): verify the ShellCheck download checksum

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,14 +29,22 @@ jobs:
       # diagnostics gate is reproducible; a distro package would drift with the
       # image.
       #
+      # SHELLCHECK_SHA256 is the SHA-256 of the linux.x86_64.tar.xz asset for
+      # SHELLCHECK_VERSION, checked before the archive is unpacked. The version
+      # pin says which release is fetched; the checksum says the bytes that
+      # arrived are the bytes upstream published. --fail only catches HTTP
+      # errors, and this binary runs against every script in the repo.
+      #
       # Renewal cadence for SHELLCHECK_VERSION: reviewed on the first Monday of
       # each quarter against https://github.com/koalaman/shellcheck/releases.
       # No scanner tracks a version embedded in a workflow step, so this cadence
       # is the renewal mechanism dependency-management Freshness requires. Bump
-      # the value and let this workflow's own run verify the new pin.
+      # both values together — the checksum renews with the version and adds no
+      # separate cadence — and let this workflow's own run verify the new pin.
       - name: Install shell gate tooling
         env:
           SHELLCHECK_VERSION: v0.11.0
+          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
         run: |
           set -euo pipefail
           sudo apt-get update
@@ -44,6 +52,10 @@ jobs:
           curl --silent --show-error --location --fail \
             "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
             --output /tmp/shellcheck.tar.xz
+          if ! echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum --check --strict; then
+            echo "error: the downloaded ShellCheck archive does not match SHELLCHECK_SHA256 — if you just bumped SHELLCHECK_VERSION, update SHELLCHECK_SHA256 to the sha256 of shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz from the release page; otherwise treat the artifact as untrusted and do not re-run until the mismatch is explained" >&2
+            exit 1
+          fi
           tar -x -J -f /tmp/shellcheck.tar.xz -C /tmp
           sudo install -m 0755 "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Changed
+
+- **The ShellCheck tarball is verified before it is unpacked** (#28) — `.github/workflows/test.yml` pinned the release version but trusted the artifact on name alone: `--fail` catches HTTP errors and says nothing about integrity, and the resulting binary runs against every shell script in the repo before the tests, on every pull request. The step now carries `SHELLCHECK_SHA256` beside `SHELLCHECK_VERSION` and checks it with `sha256sum --check --strict`, with a message that distinguishes the two ways it can fail — a forgotten checksum bump after a version bump, versus an artifact that should not be trusted. The checksum renews with the version under the quarterly cadence already documented beside the pin, so it adds no new renewal duty. Raised by Copilot as an advisory on #24 and deferred there under `review-severity` rather than folded into an already-approved PR.
+
 ## 1.1.24 — 2026-08-10
 
 ### Changed


### PR DESCRIPTION
## Scope — this is a CI change

This PR's stated scope **is** the CI workflow edit (`.github/workflows/test.yml`), per `ci-safety` Hands Off CI Config. Nothing else in the repo changes except the accompanying CHANGELOG entry.

Closes #28.

## What

`.github/workflows/test.yml` downloads the ShellCheck release tarball at a pinned version but never verifies the artifact. The step now carries `SHELLCHECK_SHA256` beside `SHELLCHECK_VERSION` and checks it with `sha256sum --check --strict` before unpacking.

```
SHELLCHECK_VERSION: v0.11.0
SHELLCHECK_SHA256:  8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
```

## Why

The pin narrows *which* release is fetched; it says nothing about integrity, and `--fail` only catches HTTP errors. The resulting binary runs against every shell script in the repo, before the tests, on every pull request. Same class of gap the SHA pin on `actions/checkout` already closes for actions.

## Provenance of the checksum

Two independent reads agree:

- GitHub's release-asset metadata: `gh api repos/koalaman/shellcheck/releases/tags/v0.11.0` reports `sha256:8c3be12b…c4e227198` for `shellcheck-v0.11.0.linux.x86_64.tar.xz`
- A fresh download through the same CDN URL the workflow uses, hashed locally: identical

## Renewal

No new duty. The comment above the step now says to bump both values together; the checksum rides the quarterly `SHELLCHECK_VERSION` review already documented there.

## Failure message

The check distinguishes the two ways it can fail — a forgotten checksum bump after a version bump, versus an artifact that should not be trusted — rather than leaving a bare `FAILED` line.

## Verification

- `bash .github/lint-shell.sh` — 7 scripts clean
- `bash .github/run-script-tests.sh` — 43 passed, 0 failed
- Install step extracted from the YAML and run through `bash -n` and ShellCheck: clean
- Checksum logic exercised both ways locally: matching digest passes, altered digest takes the error branch
- This PR's own run is the live proof the recorded digest matches what CI fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7nCygSkW8wEfeo5fedkry