### PR TITLE
feat(blog-writer): add anti-pattern #39 and scope the density doctrine

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "jbaruch/blog-writer",
   "version": "1.1.25",
   "private": false,
-  "description": "Write developer blog posts from video transcripts, meeting notes, or rough ideas — extracting narrative, structuring hooks and technical sections, formatting code placeholders, learning the author's voice through interactive onboarding, and checking drafts against 38 AI anti-patterns with three-pass scanning, craft sweep, and rewrite auditing — whenever the user wants to write a blog post, draft a blog, turn a transcript into a blog, work on blog content, or continue a blog series.",
+  "description": "Write developer blog posts from video transcripts, meeting notes, or rough ideas — extracting narrative, structuring hooks and technical sections, formatting code placeholders, learning the author's voice through interactive onboarding, and checking drafts against 39 AI anti-patterns with three-pass scanning, craft sweep, and rewrite auditing — whenever the user wants to write a blog post, draft a blog, turn a transcript into a blog, work on blog content, or continue a blog series.",
   "skills": [
     "skills/blog-writer"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### Added
+
+- **Anti-pattern #39, body-performance emotion** (#29) — a feeling delivered through the body or the room instead of named: "my stomach dropped", "the cursor blinked mockingly", "something shifted". This is the single largest human-AI gap measured in the StoryScope corpus (Russell et al. 2026, arXiv:2604.03136), which classified 61,608 stories using only discourse-level features: AI performs emotion through the body 81% of the time against 38% for humans, while humans name the feeling outright 29% against 8%. The pattern covers setting-as-mirror, sensory pile-on, the unnamed realization, and deferred naming, and carries a carve-out protecting factual physical detail — the one sock, the cat on the keyboard, the terminal output you actually saw — which is reportage and stays.
+
+### Changed
+
+- **The narrative-density doctrine is scoped, not reversed** (#29) — `tone-guide.md` opened by calling "Show, Don't Summarize" the single biggest quality differentiator, which collides with the finding above. The collision turned out to be narrower than it looked: every "good (specific)" example in that section is a *named, checkable specific* — real terminal output, a real file count — which is the half of the advice where humans beat machines roughly two to one. Only the emotional half inverted. The section now splits the rule explicitly with a push-harder / cut table, and points at #39 for the emotional half rather than restating it. No existing guidance was dropped, and the density rule still governs.
+- **The anti-pattern count reads 39 across every surface** — `SKILL.md` frontmatter and reading list, `plugin.json` description, three README claims, the `tone-guide.md` quick index (which gains its 39th entry), and five scan-procedure references in `process.md` and `ai-anti-patterns.md` that name the count in the check itself. A count that disagrees with the file it describes teaches the agent to distrust both.
+
 ## 1.1.25 — 2026-08-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Write developer blog posts from video transcripts, meeting notes, or rough ideas
 
 | Skill | What it does |
 |-------|--------------|
-| [`blog-writer`](skills/blog-writer/SKILL.md) | Turns a transcript, meeting notes, or a rough idea into a drafted blog post in the author's voice, then checks it against 38 AI writing anti-patterns |
+| [`blog-writer`](skills/blog-writer/SKILL.md) | Turns a transcript, meeting notes, or a rough idea into a drafted blog post in the author's voice, then checks it against 39 AI writing anti-patterns |
 
 ## Installation
 
@@ -34,7 +34,7 @@ can show the same thing with less abstraction.
 
 ## Anti-pattern detection
 
-Drafts are checked against 38 named AI writing anti-patterns, each with symptoms,
+Drafts are checked against 39 named AI writing anti-patterns, each with symptoms,
 examples, and alternatives (plus structural variants where applicable). The check runs
 in three passes:
 
@@ -44,7 +44,7 @@ in three passes:
 - **Soul check** — holistic read for sterile, voiceless writing that passes pattern
   checks but still reads as obviously AI
 
-Every rewrite is re-audited against all 38 patterns before it's considered fixed.
+Every rewrite is re-audited against all 39 patterns before it's considered fixed.
 
 At the start of each session the skill fetches
 [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)

--- a/skills/blog-writer/SKILL.md
+++ b/skills/blog-writer/SKILL.md
@@ -3,7 +3,7 @@ name: blog-writer
 description: >
   Write developer blog posts from video transcripts, meeting notes, or rough ideas.
   Extracts narrative from source material, structures content with hooks and technical sections,
-  formats code examples with placeholders, and checks drafts against 38 AI anti-patterns.
+  formats code examples with placeholders, and checks drafts against 39 AI anti-patterns.
   Use this skill whenever the user wants to write a blog post, draft a blog, turn a transcript
   into a blog, work on blog content, or mentions "blog" in the context of content creation.
   Also trigger when the user provides a video transcript and wants written content derived from it,
@@ -119,7 +119,7 @@ Read these reference files in order:
    other reference file.
 3. `skills/blog-writer/references/tone-guide.md` — The generic writing framework. Narrative density rules,
    anti-pattern index, tone calibration, TLDR format.
-4. `skills/blog-writer/references/ai-anti-patterns.md` — 38 named AI writing patterns to never use. Each has
+4. `skills/blog-writer/references/ai-anti-patterns.md` — 39 named AI writing patterns to never use. Each has
    symptoms, examples, structural variants, and alternatives. The anti-pattern check in
    Phase 3 and 4 scans the draft against this file.
 5. `skills/blog-writer/references/process.md` — The workflow from transcript to published draft.

--- a/skills/blog-writer/references/ai-anti-patterns.md
+++ b/skills/blog-writer/references/ai-anti-patterns.md
@@ -13,7 +13,7 @@ specific patterns, symptoms, examples, structural variants, and alternatives —
 general knowledge of AI writing patterns.
 
 **Follow the three-pass procedure exactly as written in `references/process.md`.** Pass 1
-is the surface scan against all 38 patterns. Pass 2 is the skeleton scan on adjacent
+is the surface scan against all 39 patterns. Pass 2 is the skeleton scan on adjacent
 sentence pairs. Pass 3 is the soul check — a holistic read for sterile, voiceless writing
 that passes pattern checks but still reads as AI. Then the rewrite audit. Then the voice
 check. Then the proportionality check — was the amount of rewriting proportional to the
@@ -21,7 +21,7 @@ slop found, and would the author still recognize the draft as their own voice. I
 order. Do not skip passes, do not merge them, do not substitute your own method.
 
 **Do not invent patterns that aren't in this file.** If something feels "AI-ish" but
-doesn't match any of the 38 defined patterns or their structural variants, leave it alone.
+doesn't match any of the 39 defined patterns or their structural variants, leave it alone.
 False positives from improvised rules damage the author's voice more than the pattern
 they're trying to fix.
 
@@ -1592,3 +1592,59 @@ missing fact or a missing CTA, not a missing aphorism.
 **Carve-out:** The author bio ends with a deliberate kicker (see `persona/bio.md`) — that's
 a schema element, a joke connected to the post's content, not a profundity claim. This
 pattern is about body prose endings. The bio kicker stays.
+
+---
+
+## 39. Body-Performance Emotion
+
+**The tell:** A feeling delivered through the body or the room instead of named. The
+stomach drops, the chest tightens, the cursor blinks mockingly. The emotion gets staged
+rather than stated.
+
+**Symptoms:**
+- A body part acting on the writer's behalf: chest tightening, stomach dropping, breath
+  catching, heart sinking, throat closing, hands shaking
+- The environment carrying the mood: the cold glow of the monitor, the silence of the
+  office at 3 AM, the cursor blinking accusingly
+- An emotional beat where no feeling is ever named, only performed
+- "Something shifted." "Something clicked." — an internal event reported without saying
+  what it was
+
+**Examples:**
+- ❌ "My stomach dropped when I saw the diff."
+- ❌ "I felt my chest tighten as the pipeline went red."
+- ❌ "The terminal sat there, cursor blinking, mocking me."
+- ❌ "Something shifted in how I thought about testing that day."
+- ❌ "I let out a breath I didn't know I was holding."
+
+**Structural variants:**
+- **Setting as mirror** — the weather, the lighting, or the empty office doing the
+  emotional work the sentence won't do. "The rain hadn't stopped since the incident began."
+- **Sensory pile-on** — stacking smell, sound, and texture detail at an emotional beat as
+  a substitute for saying what the beat was.
+- **The unnamed realization** — "something clicked," "it finally made sense," without ever
+  stating what clicked or what made sense.
+- **Deferred naming** — three sentences of body-performance followed by the feeling named
+  anyway. The naming was the whole sentence; the performance was throat-clearing.
+
+**Why it's a tell:** This is the single largest human-AI gap measured in the StoryScope
+corpus (Russell et al. 2026, arXiv:2604.03136): AI performs emotion through the body 81%
+of the time against 38% for human writers, while humans name the feeling outright 29%
+against 8%. It inverts the advice every writing class gives, and that's exactly why it
+became a signature — models were trained on "show, don't tell" and apply it far harder
+than people do. The underlying mechanism is worth knowing: a model reaches for a body
+because it has no feeling to report.
+
+**Instead:** Name it plainly, in the author's register. Reserve physical detail for the one
+moment that actually earns it.
+- ✅ "Honestly, that one stung."
+- ✅ "I was pissed."
+- ✅ "I read the diff twice, then went to get coffee, which is what I do instead of
+  screaming."
+
+**Carve-out — this is not a ban on physical detail.** Detail that is factually what
+happened is reportage: the one sock, the cat on the keyboard, the 2:14 AM kitchen, the
+terminal output you actually saw. That's narrative density and it stays (see
+`references/tone-guide.md`). The pattern is a body part standing in for a feeling the
+sentence declines to name. Concrete lived specifics are the human marker; body-performance
+is the machine one.

--- a/skills/blog-writer/references/process.md
+++ b/skills/blog-writer/references/process.md
@@ -364,7 +364,7 @@ comments on reconstructed code and diagrams as open questions rather than resolv
 Run the anti-pattern check (three passes). Open `references/ai-anti-patterns.md` and scan
 the draft:
 
-**Pass 1 — Surface scan:** Read the draft against each of the 38 patterns, looking for
+**Pass 1 — Surface scan:** Read the draft against each of the 39 patterns, looking for
 the forms described in the examples and structural variants. For the following patterns,
 do a dedicated mechanical sweep instead of relying on contextual reading alone:
 
@@ -468,7 +468,7 @@ not checking against specific patterns but reacting to the overall feel. Look fo
 - Uniform energy — every paragraph has the same emotional temperature
 - Press-release tone — sounds like it was written to impress rather than to communicate
 
-A draft can pass all 38 patterns and still read as obviously AI because it has no soul. If
+A draft can pass all 39 patterns and still read as obviously AI because it has no soul. If
 Pass 3 flags the draft as sterile, the fix is not another anti-pattern rewrite — it's going
 back to `persona/voice.md` and injecting the author's actual rhetorical devices, opinions,
 and attitude into the flat sections.
@@ -476,7 +476,7 @@ and attitude into the flat sections.
 Rewrite any hits. This is not optional.
 
 **Rewrite audit:** After rewriting any anti-pattern hit, re-read the replacement sentence
-in isolation and check it against ALL 38 patterns. Rewrites frequently introduce the same
+in isolation and check it against ALL 39 patterns. Rewrites frequently introduce the same
 pattern in a different surface form. This is especially true for:
 - #2 (Parallel Binary) — the most likely pattern to survive a rewrite, because describing
   a comparison naturally produces mirrored clauses. If you rewrote a parallel binary and the
@@ -485,7 +485,7 @@ pattern in a different surface form. This is especially true for:
 - #6 (Self-Answering Fragment) — rewrites often turn "The result? Great." into a longer
   question with a longer answer, but the structure is identical.
 
-Do not consider an anti-pattern fixed until the replacement passes a full 38-pattern scan
+Do not consider an anti-pattern fixed until the replacement passes a full 39-pattern scan
 on its own.
 
 **Voice check:** After confirming the rewrite is anti-pattern clean, re-read it against
@@ -563,7 +563,7 @@ conversation — edit the file surgically.
 - Re-run the anti-pattern check (`references/ai-anti-patterns.md`) after changes — all
   three passes (surface scan + skeleton scan + soul check) for new or rewritten sections.
   Apply the rewrite
-  audit rule: every rewrite must pass a full 38-pattern scan on its own before it's
+  audit rule: every rewrite must pass a full 39-pattern scan on its own before it's
   considered fixed. Then run the voice check: re-read against `persona/voice.md` and
   redo any rewrite that's clean but flat. New writing can introduce new patterns
 - Re-run the product accuracy check if any product feature descriptions, commands, or

--- a/skills/blog-writer/references/tone-guide.md
+++ b/skills/blog-writer/references/tone-guide.md
@@ -31,6 +31,32 @@ reading a report about what happened.
 - "It hardcoded — and I cannot stress this enough — HARDCODED — the loyalty program
   information directly into the source code."
 
+### What "show" does not mean: name the feeling, don't perform it
+
+The examples above all share one property — they are **named, checkable specifics**. Real
+terminal output, a real file count, a real thing that was hardcoded. That is the half of
+"show, don't tell" that reads as human, and it's the half to push harder on. Humans name
+real things at roughly twice the rate machines do.
+
+The other half — emotion staged through the body or the room — inverted while nobody was
+looking. "My stomach dropped," "the cursor blinked mockingly," "I felt something shift"
+are now the strongest single machine signature in the measured corpus, because models were
+trained on the same writing advice and follow it harder than people do. See pattern #39 in
+`references/ai-anti-patterns.md` for the full treatment.
+
+So the density rule splits cleanly:
+
+| Push harder | Cut |
+|---|---|
+| "All 47 tests passing. Build successful." | "My stomach dropped." |
+| "It scaffolded 62 files in twelve seconds." | "The terminal glowed accusingly." |
+| "It HARDCODED the loyalty program info." | "Something shifted that day." |
+| The one sock, the cat on the keyboard, 2:14 AM | "I let out a breath I didn't know I was holding." |
+
+Both columns are "specific." Only the left one is checkable. When an emotional beat needs
+to land, say the feeling in the author's own register — "honestly, that one stung" — and
+save the physical detail for the moment that actually earns it.
+
 ### How to maintain density throughout the post
 
 The opening hook always has personality because writers focus there. The quality crime happens
@@ -61,7 +87,7 @@ conference afterparty, not a whitepaper.
 
 ## Anti-Patterns: What to Never Do
 
-**Read `references/ai-anti-patterns.md` for the full list.** It contains 38 named patterns
+**Read `references/ai-anti-patterns.md` for the full list.** It contains 39 named patterns
 with symptoms, examples, and alternatives. Scan the draft against every one of them during
 Phase 3 and Phase 4. Zero tolerance.
 
@@ -104,6 +130,7 @@ Quick index for scanning:
 36. Corporate cliché phrases — "passionate team", "end-to-end solution", "trusted by industry leaders"
 37. Euphemistic smoothing — "encountered challenges" instead of "it broke"; softening failures
 38. Fake-profound kickers — mic-drop metaphor endings; delete, don't rewrite into a better metaphor
+39. Body-performance emotion — "my stomach dropped", "the cursor blinked mockingly"; name the feeling instead
 
 ---
 
@@ -408,7 +435,7 @@ Before submitting a draft, check:
 - [ ] Run a final anti-pattern check: surface scan (match examples and structural variants),
   then skeleton scan (compare grammatical structure of adjacent sentences), then soul check
   (holistic read for sterile, voiceless writing). Rewrite any hits, then re-check each
-  rewrite against all 38 patterns before considering it fixed.
+  rewrite against all 39 patterns before considering it fixed.
 
 ---
 


### PR DESCRIPTION
First of three PRs from the #29 research. Self-contained and independently useful — this one adds the prose-level finding; the structural audits and shape convergence follow separately.

## What

**Anti-pattern #39 — Body-Performance Emotion.** A feeling delivered through the body or the room instead of named: "my stomach dropped", "the cursor blinked mockingly", "something shifted". Covers setting-as-mirror, sensory pile-on, the unnamed realization, and deferred naming.

**`tone-guide.md` narrative density is scoped, not reversed.** The section opened by calling "Show, Don't Summarize" the single biggest quality differentiator. It now splits the rule explicitly and hands the emotional half to #39.

**Count cascade to 39** across every surface that names it.

## Why

The [StoryScope study](https://arxiv.org/abs/2604.03136) (Russell et al. 2026, UMD + Google DeepMind) classified 61,608 stories using *only* discourse-level features, all style withheld, at 93.2% macro-F1. Emotion mode is the single largest human-AI gap in the corpus:

| Feature | Human | AI |
| --- | --- | --- |
| Emotion via embodied metaphor | 38% | **81%** |
| Explicit emotion labels | **29%** | 8% |

None of our 38 patterns covered it.

## On the doctrine collision

`tone-guide.md:12` called "Show, Don't Summarize" the top quality differentiator, which reads as a direct contradiction. It isn't, quite. Every "good (specific)" example in that section is a **named, checkable specific** — `"All 47 tests passing"`, `HARDCODED the loyalty program info`, `62 files in twelve seconds`. That is reference specificity, where humans beat machines 47% to 24%. Only the *emotional* half of "show don't tell" inverted.

So the section keeps its doctrine and gains a table separating the two:

| Push harder | Cut |
| --- | --- |
| "All 47 tests passing. Build successful." | "My stomach dropped." |
| "It scaffolded 62 files in twelve seconds." | "The terminal glowed accusingly." |

Both columns are "specific." Only the left one is checkable. No existing guidance was dropped.

## Carve-out worth reviewing

#39 explicitly does **not** ban physical detail. Factual detail — the one sock, the cat on the keyboard, the 2:14 AM kitchen — is reportage and stays. The pattern is a body part standing in for a feeling the sentence declines to name. Without this carve-out, #39 would fight the density doctrine it is meant to complement, and would break persona devices that depend on lived physical detail.

## Surface sync

| Surface | Change |
| --- | --- |
| `ai-anti-patterns.md` | +#39; check-procedure count 38 → 39 |
| `tone-guide.md` | density section scoped; quick index +39th entry; 2 counts |
| `process.md` | 4 scan-procedure counts |
| `SKILL.md` | frontmatter description + reading list |
| `plugin.json` | description |
| `README.md` | 3 claims |
| `CHANGELOG.md` | un-headed `###` blocks for the stamp step |

Five of those counts sit *inside* the scan procedure ("check it against ALL 38 patterns"), so a stale count would have instructed the agent to run an incomplete scan.

## Verification

- `bash .github/lint-shell.sh` — 7 scripts clean
- `bash .github/run-script-tests.sh` — 43 passed, 0 failed
- `tessl plugin lint` — valid
- `grep -cE "^## [0-9]+\. "` on the anti-pattern file returns **39**
- Full-repo sweep for surviving `38` references: only the `## 38.` heading, the 38% StoryScope stat, the quick-index line for #38, and `evals/summary.json` reason counts — all legitimate

## Not in this PR

No eval scenario. Per the credit review: the org is at 5,090/1,000 credits, blog-writer is not project-linked, and evals stay manual and unwired from publish so they never compete with skill review for the same budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7nCygSkW8wEfeo5fedkry